### PR TITLE
Add support for Thunderbolt 4 Dock Chroma

### DIFF
--- a/src/include/razeraccessory_driver.h
+++ b/src/include/razeraccessory_driver.h
@@ -15,6 +15,7 @@
 #ifndef __HID_RAZER_ACCESSORY_H
 #define __HID_RAZER_ACCESSORY_H
 
+#define USB_DEVICE_ID_RAZER_MOUSE_DOCK 0x007E
 #define USB_DEVICE_ID_RAZER_NOMMO_CHROMA 0x0517
 #define USB_DEVICE_ID_RAZER_NOMMO_PRO 0x0518
 #define USB_DEVICE_ID_RAZER_CHROMA_MUG 0x0F07
@@ -22,9 +23,13 @@
 #define USB_DEVICE_ID_RAZER_CHROMA_HDK 0x0F09
 #define USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA 0x0F1D
 #define USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA 0x0F20
+#define USB_DEVICE_ID_RAZER_THUNDERBOLT_4_DOCK_CHROMA 0x0F21
 
 #define RAZER_ACCESSORY_WAIT_MIN_US 600
 #define RAZER_ACCESSORY_WAIT_MAX_US 1000
+
+#define RAZER_NEW_DEVICE_WAIT_MIN_US 31000
+#define RAZER_NEW_DEVICE_WAIT_MAX_US 31100
 
 ssize_t razer_accessory_attr_write_mode_none(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);
 ssize_t razer_accessory_attr_write_mode_spectrum(IOUSBDeviceInterface **usb_dev, const char *buf, size_t count);

--- a/src/lib/razerdevice.c
+++ b/src/lib/razerdevice.c
@@ -216,6 +216,7 @@ bool is_accessory(IOUSBDeviceInterface **usb_dev)
         case USB_DEVICE_ID_RAZER_CHROMA_HDK:
         case USB_DEVICE_ID_RAZER_MOUSE_BUNGEE_V3_CHROMA:
         case USB_DEVICE_ID_RAZER_BASE_STATION_V2_CHROMA:
+        case USB_DEVICE_ID_RAZER_THUNDERBOLT_4_DOCK_CHROMA:
             return true;
     }
 


### PR DESCRIPTION
This PR adds support for the Razer Thunderbolt 4 Chroma dock by merging in the relevant code from openrazer. This support has been tested against the Thunderbolt 4 Chroma dock sitting on my desk, which I can confirm works as expected.

I also added the conditional logic to `razeraccessory_driver.c` for the mouse dock, which appears to have replaced the `razermousedock_driver` files in openrazer best that I can tell. This code is dormant, as the relevant functionality is still pushed to the `razermousedock_driver` functions, but I figured adding the hooks at the same time was free, and might save someone some effort in the future if someone wants to decommission the razermousedock_driver files.

If you'd prefer to have a single-feature PR let me know and I can delete the mouse dock work -- it's the Thunderbolt dock support I was looking for!