### PR TITLE
Fix Basilisk V3 Error

### DIFF
--- a/src/lib/razermouse_driver.c
+++ b/src/lib/razermouse_driver.c
@@ -49,10 +49,8 @@ static int razer_get_report(IOUSBDeviceInterface **usb_dev, struct razer_report 
     UInt16 product = -1;
     (*usb_dev)->GetDeviceProduct(usb_dev, &product);
 
+    unsigned int index = 0;
     switch (product) {
-    case USB_DEVICE_ID_RAZER_BASILISK_V3:
-        return razer_get_usb_response(usb_dev, 0x03, request_report, 0x00, response_report, RAZER_NEW_MOUSE_RECEIVER_WAIT_MIN_US);
-        break;
     case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_RECEIVER:
     case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS_WIRED:
     case USB_DEVICE_ID_RAZER_LANCEHEAD_WIRELESS:
@@ -61,13 +59,13 @@ static int razer_get_report(IOUSBDeviceInterface **usb_dev, struct razer_report 
     case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
     case USB_DEVICE_ID_RAZER_BASILISK_ULTIMATE_RECEIVER:
-        return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_NEW_MOUSE_RECEIVER_WAIT_MIN_US);
+        return razer_get_usb_response(usb_dev, index, request_report, index, response_report, RAZER_NEW_MOUSE_RECEIVER_WAIT_MIN_US);
         break;
 
     case USB_DEVICE_ID_RAZER_ATHERIS_RECEIVER:
     case USB_DEVICE_ID_RAZER_OROCHI_V2_RECEIVER:
     case USB_DEVICE_ID_RAZER_OROCHI_V2_BLUETOOTH:
-        return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_ATHERIS_RECEIVER_WAIT_MIN_US);
+        return razer_get_usb_response(usb_dev, index, request_report, index, response_report, RAZER_ATHERIS_RECEIVER_WAIT_MIN_US);
         break;
 
     case USB_DEVICE_ID_RAZER_VIPER_ULTIMATE_WIRELESS:
@@ -75,11 +73,16 @@ static int razer_get_report(IOUSBDeviceInterface **usb_dev, struct razer_report 
     case USB_DEVICE_ID_RAZER_NAGA_TRINITY:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRELESS:
     case USB_DEVICE_ID_RAZER_DEATHADDER_V2_PRO_WIRED:
-        return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_VIPER_MOUSE_RECEIVER_WAIT_MIN_US);
+        return razer_get_usb_response(usb_dev, index, request_report, index, response_report, RAZER_VIPER_MOUSE_RECEIVER_WAIT_MIN_US);
         break;
-
+            
+    case USB_DEVICE_ID_RAZER_BASILISK_V3:
+        index = 0x03;
+        return razer_get_usb_response(usb_dev, index, request_report, index, response_report, RAZER_NEW_MOUSE_RECEIVER_WAIT_MIN_US);
+        break;
+            
     default:
-        return razer_get_usb_response(usb_dev, 0x00, request_report, 0x00, response_report, RAZER_MOUSE_WAIT_MIN_US);
+        return razer_get_usb_response(usb_dev, index, request_report, index, response_report, RAZER_MOUSE_WAIT_MIN_US);
     }
 }
 

--- a/src/lib/razermouse_driver.c
+++ b/src/lib/razermouse_driver.c
@@ -1947,6 +1947,7 @@ void razer_attr_write_matrix_brightness(IOUSBDeviceInterface **usb_dev, unsigned
         case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
         case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
         case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
+        case USB_DEVICE_ID_RAZER_BASILISK_V3:
             report = razer_chroma_extended_matrix_brightness(VARSTORE, 0x00, brightness);
             report.transaction_id.id = 0x1F;
             break;
@@ -1998,6 +1999,7 @@ ushort razer_attr_read_matrix_brightness(IOUSBDeviceInterface **usb_dev)
         case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRELESS:
         case USB_DEVICE_ID_RAZER_NAGA_PRO_WIRED:
         case USB_DEVICE_ID_RAZER_MAMBA_ELITE:
+        case USB_DEVICE_ID_RAZER_BASILISK_V3:
             report = razer_chroma_extended_matrix_get_brightness(VARSTORE, 0x00);
             report.transaction_id.id = 0x1F;
             break;


### PR DESCRIPTION
The original PR #16 has an incorrect value for `request_report` and forgot to add support for matrix brightness. There are bugs reported on the frontend that this will correct. Furthermore, I used the opportunity to mirror the openrazer implementation for the Basilisk V3. [Source](https://github.com/openrazer/openrazer/pull/1703/files#diff-ae344621219321be2defd9ca4571cf69022e8339e72be8c30d2b54a090391667)